### PR TITLE
Add skeleton Electron TTS reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Test
-for testing
+# My Reader
+
+This project is a cross-platform desktop application built with Electron. It reads text from TXT, PDF, and DOCX files aloud using the system text-to-speech voices.
+
+## Features
+
+- Open TXT, PDF, or DOCX files
+- Choose among installed system voices
+- Play and stop playback
+- Adjustable reading speed
+- Dark themed interface
+
+## Development
+
+Install dependencies and start the app:
+
+```bash
+npm install
+npm start
+```
+
+Use `electron-builder` to package a portable build:
+
+```bash
+npx electron-builder --dir
+```

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>My Reader</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="controls">
+    <button id="open">Open File</button>
+    <select id="voices"></select>
+    <button id="play">Play</button>
+    <button id="pause">Pause</button>
+    <button id="stop">Stop</button>
+    <label>Speed <input type="range" id="speed" min="0.5" max="2" step="0.1" value="1"></label>
+  </div>
+  <pre id="content"></pre>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -1,0 +1,44 @@
+const contentEl = document.getElementById('content');
+const openBtn = document.getElementById('open');
+const playBtn = document.getElementById('play');
+const pauseBtn = document.getElementById('pause');
+const stopBtn = document.getElementById('stop');
+const voicesSel = document.getElementById('voices');
+const speedInput = document.getElementById('speed');
+
+let textContent = '';
+let currentVoice = null;
+
+window.api.getVoices().then(vs => {
+  vs.forEach(v => {
+    const opt = document.createElement('option');
+    opt.textContent = v;
+    opt.value = v;
+    voicesSel.appendChild(opt);
+  });
+  if (vs.length) currentVoice = vs[0];
+});
+
+voicesSel.addEventListener('change', () => {
+  currentVoice = voicesSel.value;
+});
+
+openBtn.addEventListener('click', async () => {
+  const { text } = await window.api.openFile();
+  if (text) {
+    textContent = text;
+    contentEl.textContent = textContent;
+  }
+});
+
+playBtn.addEventListener('click', () => {
+  window.api.speak(textContent, { voice: currentVoice, speed: parseFloat(speedInput.value) });
+});
+
+pauseBtn.addEventListener('click', () => {
+  // say doesn't support pause/resume directly
+});
+
+stopBtn.addEventListener('click', () => {
+  window.api.stop();
+});

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,0 +1,24 @@
+body {
+  background: #111;
+  color: #eee;
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1em;
+}
+
+#controls {
+  margin-bottom: 1em;
+}
+
+button, select, input {
+  margin-right: 0.5em;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #222;
+  padding: 1em;
+  border-radius: 4px;
+  max-height: 60vh;
+  overflow: auto;
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,64 @@
+const { app, BrowserWindow, dialog, ipcMain } = require('electron');
+const path = require('path');
+const fs = require('fs');
+const pdf = require('pdf-parse');
+const mammoth = require('mammoth');
+const say = require('say');
+
+let mainWindow;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+  mainWindow.loadFile(path.join(__dirname, 'app', 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+ipcMain.handle('open-file', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
+    filters: [
+      { name: 'Documents', extensions: ['txt', 'pdf', 'docx'] }
+    ],
+    properties: ['openFile']
+  });
+  if (canceled || !filePaths.length) return { text: null };
+  const filePath = filePaths[0];
+  if (filePath.endsWith('.txt')) {
+    const text = fs.readFileSync(filePath, 'utf8');
+    return { text };
+  } else if (filePath.endsWith('.pdf')) {
+    const dataBuffer = fs.readFileSync(filePath);
+    const data = await pdf(dataBuffer);
+    return { text: data.text };
+  } else if (filePath.endsWith('.docx')) {
+    const result = await mammoth.extractRawText({ path: filePath });
+    return { text: result.value };
+  }
+  return { text: null };
+});
+
+ipcMain.handle('speak', (_, text, opts) => {
+  say.speak(text, opts?.voice || null, opts?.speed || 1.0);
+});
+
+ipcMain.handle('stop-speech', () => {
+  say.stop();
+});
+
+ipcMain.handle('get-voices', () => {
+  return new Promise((resolve) => {
+    say.getInstalledVoices((err, voices) => {
+      if (err) resolve([]); else resolve(voices);
+    });
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "my-reader",
+  "version": "0.1.0",
+  "description": "Cross-platform PDF/TXT/DOC reader with TTS",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^26.2.2",
+    "pdf-parse": "^1.1.1",
+    "mammoth": "^1.4.21",
+    "say": "^0.16.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.6.0"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  openFile: () => ipcRenderer.invoke('open-file'),
+  speak: (text, opts) => ipcRenderer.invoke('speak', text, opts),
+  stop: () => ipcRenderer.invoke('stop-speech'),
+  getVoices: () => ipcRenderer.invoke('get-voices')
+});


### PR DESCRIPTION
## Summary
- build initial Electron skeleton for reading TXT, PDF and DOCX files aloud
- implement main process, preload bridge, and basic dark-themed UI
- add instructions in README

## Testing
- `node -v`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_684fe00f65c883329d47eb6dd763272d